### PR TITLE
Warning message and soft fail when rendering widget grid with no default indicator for subgroup

### DIFF
--- a/layout/widgets-grid/component.tsx
+++ b/layout/widgets-grid/component.tsx
@@ -36,6 +36,10 @@ const WidgetsGrid: FC<WidgetsGridProps> = ({
         slug: subgroupSlug,
         default_indicator,
       }) => {
+        if (!default_indicator) {
+          console.warn(`Widget grid rendering: Group (with slug) ${groupSlug} subgroup (with slug) ${subgroupSlug} has no default indicator data. Widgets may not work correctly.`);
+          return null;
+        }
         const {
           id,
           name,


### PR DESCRIPTION
⚠️ Before submitting the PR:

- Ran the tests: `yarn test`
- Update the changelog
- Ask someone to review it
- Chose a meaningful title

---

Description of the PR

## Testing instructions

What to test? How to do it?

## Jira

Link to the task(s), if any
