### PR TITLE
Add pagination to bar charts with data bigger then 30 items

### DIFF
--- a/components/paginated-dynamic-chart/component.tsx
+++ b/components/paginated-dynamic-chart/component.tsx
@@ -1,0 +1,92 @@
+import React, {
+  useEffect, useMemo, useState, cloneElement, Children, ReactElement,
+} from 'react';
+import Button from 'components/button';
+import Icon from 'components/icon';
+import classNames from 'classnames';
+
+type ChartProps = {
+  widgetData: unknown[];
+};
+
+type PaginatedDynamicChartProps = ChartProps & {
+  /** Max page items */
+  maxItems?: number,
+  /** Dynamic chart element */
+  children: ReactElement<ChartProps>
+};
+
+/** Max bar chart items */
+const MAX_ITEMS = 30;
+const initialPagination = { from: 0, to: MAX_ITEMS };
+
+/** Sort the data by Total and paginate the chart elements by maxItems */
+const PaginatedDynamicChart = ({ widgetData, maxItems = MAX_ITEMS, children }
+: PaginatedDynamicChartProps) => {
+  const [pagination, setPagination] = useState(initialPagination);
+  const child = Children.only(children);
+
+  useEffect(() => {
+    setPagination(initialPagination);
+  }, [widgetData]);
+
+  const sortedData = useMemo(() => {
+    if (Array.isArray(widgetData)) {
+      return widgetData.filter((d) => !!d.Total).sort((a, b) => Number(b.Total) - Number(a.Total));
+    }
+    return [];
+  }, [widgetData]);
+
+  const handleClick = (direction: 'next' | 'prev') => {
+    if (direction === 'next') {
+      if (pagination.to < widgetData.length) {
+        setPagination({ from: pagination.to, to: pagination.to + maxItems });
+      }
+    } else if (pagination.from > 0) {
+      setPagination({ from: pagination.from - maxItems, to: pagination.from });
+    }
+  };
+
+  const data = sortedData.slice(pagination.from, pagination.to);
+  const isFirst = pagination.from === 0;
+  const isLast = pagination.to >= sortedData.length;
+
+  return (
+    <div className="w-full h-full mt-2">
+      <div className="flex justify-between">
+        <Button onClick={() => handleClick('prev')}>
+          <Icon
+            ariaLabel="category-up"
+            name="triangle_border"
+            size="xlg"
+            onClick={() => handleClick('prev')}
+            className={classNames('p-2 mr-3 transform rotate-90 border-2 rounded-full border-gray1 border-opacity-30 text-gray1', {
+              'cursor-pointer hover:bg-gray1 hover:bg-opacity-90 hover:text-white': !isFirst,
+              'opacity-30 cursor-auto': isFirst,
+            })}
+          />
+        </Button>
+        <Button size="sm" onClick={() => handleClick('next')}>
+          <Icon
+            ariaLabel="category-up"
+            name="triangle_border"
+            size="xlg"
+            onClick={() => handleClick('next')}
+            className={classNames('p-2 mr-3 transform -rotate-90 border-2 rounded-full  border-gray1 border-opacity-30 text-gray1', {
+              'cursor-pointer hover:bg-gray1 hover:bg-opacity-90 hover:text-white': !isLast,
+              'opacity-30 cursor-auto': isLast,
+            })}
+          />
+        </Button>
+      </div>
+      {
+        cloneElement(child, {
+          ...child.props,
+          widgetData: data,
+        })
+      }
+    </div>
+  );
+};
+
+export default PaginatedDynamicChart;

--- a/components/paginated-dynamic-chart/component.tsx
+++ b/components/paginated-dynamic-chart/component.tsx
@@ -11,24 +11,22 @@ type ChartProps = {
 
 type PaginatedDynamicChartProps = ChartProps & {
   /** Max page items */
-  maxItems?: number,
+  maxItems: number,
   /** Dynamic chart element */
   children: ReactElement<ChartProps>
 };
 
-/** Max bar chart items */
-const MAX_ITEMS = 30;
-const initialPagination = { from: 0, to: MAX_ITEMS };
-
 /** Sort the data by Total and paginate the chart elements by maxItems */
-const PaginatedDynamicChart = ({ widgetData, maxItems = MAX_ITEMS, children }
+const PaginatedDynamicChart = ({ widgetData, maxItems, children }
 : PaginatedDynamicChartProps) => {
+  const initialPagination = useMemo(() => ({ from: 0, to: maxItems }), [maxItems]);
+
   const [pagination, setPagination] = useState(initialPagination);
   const child = Children.only(children);
 
   useEffect(() => {
     setPagination(initialPagination);
-  }, [widgetData]);
+  }, [initialPagination, widgetData]);
 
   const sortedData = useMemo(() => {
     if (Array.isArray(widgetData)) {

--- a/layout/indicator-data/general/component.tsx
+++ b/layout/indicator-data/general/component.tsx
@@ -60,6 +60,8 @@ type ChartProps = {
 };
 
 const BUTTON_STYLES = 'text-sm mb-2 flex items-center border text-color1 border-gray1 border-opacity-20 py-0.5 px-4 rounded-full mr-4 whitespace-nowrap';
+/** Max bar chart items */
+const MAX_ITEMS = 30;
 
 const IndicatorChart: FC<ComponentTypes> = ({ className }: ComponentTypes) => {
   const [dropdownVisibility, setDropdownVisibility] = useState({
@@ -622,8 +624,9 @@ const IndicatorChart: FC<ComponentTypes> = ({ className }: ComponentTypes) => {
                   {visualization !== 'choropleth' && (
                     <div className="w-full h-96">
                       {
-                          (visualization === 'bar' && Array.isArray(widgetData) && widgetData.length > 20) ? (
+                          (visualization === 'bar' && Array.isArray(widgetData) && widgetData.length > MAX_ITEMS) ? (
                             <PaginatedDynamicChart
+                              maxItems={MAX_ITEMS}
                               widgetData={widgetData}
                             >
                               <DynamicChart

--- a/layout/indicator-data/general/component.tsx
+++ b/layout/indicator-data/general/component.tsx
@@ -26,6 +26,7 @@ import Legend from 'components/legend';
 import DataSource from 'components/data-source';
 import MapContainer from 'components/indicator-visualizations/choropleth';
 import LoadingSpinner from 'components/loading-spinner';
+import PaginatedDynamicChart from 'components/paginated-dynamic-chart/component';
 
 // utils
 import {
@@ -383,6 +384,7 @@ const IndicatorChart: FC<ComponentTypes> = ({ className }: ComponentTypes) => {
 
   useEffect(() => {
     if (category?.label === 'category_1' && subcategories.length === 1) { setSubcategoriesTotals(LegendPayload); }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [category, subcategories.length, setSubcategoriesTotals]);
 
   const singleValueLegendColor = useMemo(
@@ -619,12 +621,28 @@ const IndicatorChart: FC<ComponentTypes> = ({ className }: ComponentTypes) => {
                   )}
                   {visualization !== 'choropleth' && (
                     <div className="w-full h-96">
-                      <DynamicChart
-                        widgetData={widgetData}
-                        widgetConfig={widgetConfig}
-                        colors={colors}
-                        color={singleValueLegendColor}
-                      />
+                      {
+                          (visualization === 'bar' && Array.isArray(widgetData) && widgetData.length > 20) ? (
+                            <PaginatedDynamicChart
+                              widgetData={widgetData}
+                            >
+                              <DynamicChart
+                                widgetData={widgetData}
+                                widgetConfig={widgetConfig}
+                                colors={colors}
+                                color={singleValueLegendColor}
+                              />
+                            </PaginatedDynamicChart>
+                          )
+                            : (
+                              <DynamicChart
+                                widgetData={widgetData}
+                                widgetConfig={widgetConfig}
+                                colors={colors}
+                                color={singleValueLegendColor}
+                              />
+                            )
+                        }
                     </div>
                   )}
                   {visualization === 'choropleth' && (

--- a/pages/[group]/[...subgroup].tsx
+++ b/pages/[group]/[...subgroup].tsx
@@ -91,7 +91,7 @@ const GroupPage: FC<GroupPageTypes> = ({ groupSlug }: GroupPageTypes) => {
         <section className="z-10 max-w-6xl m-auto -mt-40">
           {groupSlug !== 'energy-balance' && <IndicatorData />}
           {groupSlug === 'energy-balance' && <EnergyBalanceIndicatorData />}
-          {/* {groupSlug !== 'energy-flows' && groupSlug !== 'energy-balance' && <WidgetsGrid />} */}
+          {groupSlug !== 'energy-flows' && groupSlug !== 'energy-balance' && <WidgetsGrid />}
         </section>
       </div>
 


### PR DESCRIPTION
This PR adds pagination to bar charts with the data length equal or bigger than 30 items

[Test link](http://localhost:3000/socioeconomic/trade-and-investment/trade-and-investment-international-trade-in-goods-by-country-region-of-origindestination)

